### PR TITLE
Set target-cpu=native

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]
+


### PR DESCRIPTION
Setting the target-cpu to native can get you performance improvements.

Here are the before and after results on my laptop (macbook, with i9 CPU).

Before:
```
test bench_naive_bytes         ... bench:           7 ns/iter (+/- 0) = 2285 MB/s
test bench_naive_bytes_and     ... bench:           6 ns/iter (+/- 0) = 2666 MB/s
test bench_naive_bytes_and_c16 ... bench:           6 ns/iter (+/- 2) = 2666 MB/s
test bench_naive_bytes_iter    ... bench:           7 ns/iter (+/- 1) = 2285 MB/s
test bench_naive_chars         ... bench:          10 ns/iter (+/- 0) = 1600 MB/s
test bench_naive_chars_and     ... bench:           9 ns/iter (+/- 0) = 1777 MB/s
test bench_naive_chars_iter    ... bench:          10 ns/iter (+/- 0) = 1600 MB/s
test bench_str_parse           ... bench:          19 ns/iter (+/- 5) = 842 MB/s
test bench_trick               ... bench:           3 ns/iter (+/- 0) = 5333 MB/s
test bench_trick_128           ... bench:           4 ns/iter (+/- 0) = 4000 MB/s
test bench_trick_simd          ... bench:           3 ns/iter (+/- 0) = 5333 MB/s
test bench_trick_simd_c16      ... bench:          13 ns/iter (+/- 2) = 1230 MB/s
test bench_unrolled            ... bench:          12 ns/iter (+/- 1) = 1333 MB/s
test bench_unrolled_safe       ... bench:          11 ns/iter (+/- 0) = 1454 MB/s
test bench_unrolled_unsafe     ... bench:          11 ns/iter (+/- 1) = 1454 MB/s
```

After:
```
test bench_naive_bytes         ... bench:           7 ns/iter (+/- 1) = 2285 MB/s
test bench_naive_bytes_and     ... bench:           6 ns/iter (+/- 0) = 2666 MB/s
test bench_naive_bytes_and_c16 ... bench:           6 ns/iter (+/- 0) = 2666 MB/s
test bench_naive_bytes_iter    ... bench:           7 ns/iter (+/- 2) = 2285 MB/s
test bench_naive_chars         ... bench:          10 ns/iter (+/- 0) = 1600 MB/s
test bench_naive_chars_and     ... bench:           8 ns/iter (+/- 0) = 2000 MB/s
test bench_naive_chars_iter    ... bench:          11 ns/iter (+/- 1) = 1454 MB/s
test bench_str_parse           ... bench:          19 ns/iter (+/- 2) = 842 MB/s
test bench_trick               ... bench:           3 ns/iter (+/- 0) = 5333 MB/s
test bench_trick_128           ... bench:           4 ns/iter (+/- 0) = 4000 MB/s
test bench_trick_simd          ... bench:           1 ns/iter (+/- 0) = 16000 MB/s
test bench_trick_simd_c16      ... bench:           2 ns/iter (+/- 0) = 8000 MB/s
test bench_unrolled            ... bench:           7 ns/iter (+/- 0) = 2285 MB/s
test bench_unrolled_safe       ... bench:           6 ns/iter (+/- 1) = 2666 MB/s
test bench_unrolled_unsafe     ... bench:           6 ns/iter (+/- 0) = 2666 MB/s
```

The fastest time is now 1ns!